### PR TITLE
Add a test to verify if file is not undefined

### DIFF
--- a/lib/file-set.js
+++ b/lib/file-set.js
@@ -67,15 +67,17 @@ FileSet.prototype.add = function (files) {
   files = arrayify(files)
   files.forEach(function (file) {
     try {
-      var stat = fs.statSync(file)
-      if (stat.isFile()) {
-        if (self.files.indexOf(file) === -1) self.files.push(file)
-      } else if (stat.isDirectory()) {
-        if (self.dirs.indexOf(file) === -1) self.dirs.push(file)
+      if (file) {
+        var stat = fs.statSync(file)
+        if (stat.isFile()) {
+          if (self.files.indexOf(file) === -1) self.files.push(file)
+        } else if (stat.isDirectory()) {
+          if (self.dirs.indexOf(file) === -1) self.dirs.push(file)
+        }
       }
     } catch (err) {
       if (err.code === 'ENOENT') {
-        var found = glob.sync(file, { mark: true })
+        var found = glob.sync(file, {mark: true})
         if (found.length) {
           found.forEach(function (match) {
             if (match.endsWith('/')) {


### PR DESCRIPTION
Hello,

If passed array of files contains `undefined` values, an error occurs during the loop.

This error occurs using partial features of [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) [v4.0.1](https://github.com/jsdoc2md/jsdoc-to-markdown/tree/v4.0.1).

I propose to check the value and jump if `file` is undefined.

Are you ok for this pull request ? :-)

Kind regards,